### PR TITLE
fix(feed): emit built (asset-hashed) image URLs so feed images don't 404

### DIFF
--- a/blog/.vitepress/config.mts
+++ b/blog/.vitepress/config.mts
@@ -7,6 +7,20 @@ import version from '../../package.json'
 
 const hostname: string = 'https://chris.pelatari.com'
 
+// Per-post, asset-resolved render captured from VitePress's own transform (see transformHtml below).
+// createContentLoader renders with markdown-it BEFORE Vite hashes assets, so its <img src> are raw
+// source paths (./images/foo.png) that 404 against the hashed build output (/assets/foo.HASH.png).
+// The site pages get the hashed URLs; the feed didn't -- two render engines, one disconnect. Capturing
+// the page's resolved content here gives the feed the same URLs the browser gets.
+const renderedPosts = new Map<string, string>()
+const slug = (p: string) =>
+  p.replace(/^\//, '').replace(/\.(md|html)$/i, '').replace(/\/index$/i, '').replace(/\/$/, '')
+// Syndicated content should use absolute URLs: the page render emits root-relative /assets (hashed)
+// and /images (public) paths, which a standalone reader would resolve against its own host. Targeted
+// so external absolute URLs and protocol-relative (//) paths are left untouched.
+const absolutize = (h: string) =>
+  h.replaceAll('"/assets/', `"${hostname}/assets/`).replaceAll('"/images/', `"${hostname}/images/`)
+
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: 'Blue Fenix',
@@ -59,6 +73,12 @@ export default defineConfig({
   cleanUrls: true,
   srcExclude: ['**/README.md', '**/TODO.md', '**/drafts/**'],
   appearance: 'dark',
+  // Capture each post's final, asset-resolved content (img src already Vite-hashed) so the feed can
+  // reuse the site's own render instead of re-rendering with markdown-it. Reading ctx only -- no mutation.
+  transformHtml(_code, _id, ctx) {
+    const rel = ctx.pageData.relativePath
+    if (rel.startsWith('posts/') && ctx.content) renderedPosts.set(slug(rel), ctx.content)
+  },
   buildEnd: async (config: SiteConfig) => {
     const feed = new Feed({
       title: 'Blue Fenix Productions',
@@ -66,7 +86,7 @@ export default defineConfig({
       id: hostname,
       link: `${hostname}/about`,
       language: 'en',
-      image: `${hostname}/IMG_1996.png`,
+      image: `${hostname}/images/IMG_1996.png`,
       favicon: `${hostname}/favicon.ico`,
       feedLinks: {
         rss: `${hostname}/feed.xml`,
@@ -89,13 +109,16 @@ export default defineConfig({
       //get the date from the file name - all of them are in the format YYYY-MM-DD-title.md
       // @ts-ignore: Object is possibly 'undefined'
       const date = new Date(url.split('/').pop().slice(0, 10))
+      const resolved = renderedPosts.get(slug(url))
 
       feed.addItem({
         title: frontmatter.title,
         id: `${hostname}${url}`,
         link: `${hostname}${url}`,
         description: excerpt,
-        content: html,
+        // The site's asset-resolved render (hashed img URLs), absolutized; fall back to the markdown-it
+        // render only if a post somehow wasn't captured by transformHtml.
+        content: resolved ? absolutize(resolved) : html,
         author: [
           {
             name: 'Chris Pelatari',


### PR DESCRIPTION
## Problem

The RSS feed shipped `<img>` URLs that **404 on the served site** — so feed readers (and my RSS Bandit reader, which is what surfaced this) showed broken images for every VitePress-era post.

Root cause: **two render engines.** `buildEnd` builds the feed from `createContentLoader({ render: true })`, which renders posts with **markdown-it, *before* Vite hashes assets** — so its image `src` are the raw source paths (`./images/foo.png`, `/assets/images/foo.gif`). The actual built pages serve **content-hashed** paths (`/assets/foo.HASH.png`). The pages got the hashes; the feed never saw them.

The hash is a *bundle output*, so nothing rendered before Vite finishes can know it — the feed has to consume a post-bundle artifact.

## Fix

Reuse **VitePress's own render** instead of a second markdown-it pass:

- A `transformHtml` hook captures each post's final, asset-resolved content (`ctx.content` already carries the hashed `<img src>` — no re-render, no HTML parsing, no manifest correlation), keyed by slug.
- `buildEnd` uses that captured content for the feed item, **absolutized** (`/assets/…`, `/images/…` → `https://chris.pelatari.com/…`) so any standalone reader loads the images.
- Channel image fix: it pointed at `/IMG_1996.png`, but the file is served at `/images/IMG_1996.png` (it lives in `public/images/`).

Net: feed and site share one render engine and one set of URLs.

## Verification (real `vitepress build blog`)

- Feed now carries **24 absolute hashed asset URLs**, **zero** raw `./images/` or `/assets/images/` source paths.
- The generated hashes match the deployed build (content-deterministic) — spot-checked several against the **live** site, all `200`:
  - `…/assets/image_magick_version.0E3BDGNv.png` ✅
  - `…/assets/SyntaxHighlighting1.CA42sN3A.gif` ✅
  - `…/assets/andre_3000.DVZwWBWH.jpg` ✅
  - `…/images/IMG_1996.png` (channel image) ✅

## Note
`transformHtml`'s `ctx.content` carried the hashed URLs directly, so no `node-html-parser`/cheerio fallback was needed. If a future VitePress version changes that, `ctx.assets` (documented as fully-resolved public URLs) is the backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Tn3QCyQBdG2DxwEPoKZTWW
